### PR TITLE
bugfix: where `--clusters`/`-C` flag was ignored during generation

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -127,7 +127,7 @@ func GenerateCommand(cmd *cobra.Command, args []string) {
 func GenerateCmdClusterListBuilder(allClusterParams map[string]string) []string {
 	var clusterList []string
 	// Filter out and cluster or components we don't want to generate
-	if cmdGenerateFlags.Filters.Includes != "" || cmdGenerateFlags.Filters.Excludes != "" {
+	if cmdGenerateFlags.Filters.Includes != "" || cmdGenerateFlags.Filters.Excludes != "" || cmdGenerateFlags.Filters.Clusters != "" {
 		clusterList = util.CalculateClusterIncludesExcludes(allClusterParams, cmdGenerateFlags.Filters)
 		log.Debug().Msg("Have " + strconv.Itoa(len(clusterList)) + " after filtering")
 	} else {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -90,9 +90,11 @@ func FilterItems(input map[string]string, pFilter PathFilterOptions) []string {
 		gjResult := gjson.Parse(input[c])
 		// filter on cluster parameters, passed in gjson path notation with either
 		// "=" for equality or "~" for regex match
-		include := false
-		for _, b := range strings.Split(pFilter.Includes, ",") {
-			include = include || CheckObjectMatch(gjResult, b)
+		include := pFilter.Includes == ""
+		if pFilter.Includes != "" {
+			for _, b := range strings.Split(pFilter.Includes, ",") {
+				include = include || CheckObjectMatch(gjResult, b)
+			}
 		}
 		if !include {
 			continue
@@ -107,6 +109,7 @@ func FilterItems(input map[string]string, pFilter PathFilterOptions) []string {
 		if exclude {
 			continue
 		}
+		clusterList = append(clusterList, c)
 	}
 
 	return clusterList
@@ -119,10 +122,15 @@ func CalculateClusterIncludesExcludes(input map[string]string, filters PathFilte
 	if filters.Clusters != "" {
 		var clusterList []string
 		// all clusters
-		for _, key := range strings.Split(filters.Clusters, ",") {
-			val, ok := input[key]
-			if ok {
-				clusterList = append(clusterList, val)
+		for key := range input {
+			for _, filterPattern := range strings.Split(filters.Clusters, ",") {
+				if key == filterPattern {
+					clusterList = append(clusterList, key)
+					break
+				} else if matched, err := regexp.MatchString(filterPattern, key); err == nil && matched {
+					clusterList = append(clusterList, key)
+					break
+				}
 			}
 		}
 


### PR DESCRIPTION
This commit resolves multiple bugs within the cluster filtering pipeline that prevented the `-C` flag from correctly filtering target clusters during the generation command. 

Details:
- cmd/generate.go: Added `Filters.Clusters` to the validation check. Previously, cluster filtering wouldn't trigger unless `--clincludes` or `--clexcludes` were explicitly set, causing it to fall back to generating all clusters.
- pkg/util/util.go (CalculateClusterIncludesExcludes): Fixed a critical bug where the JSON parameter map value was appended to the generated cluster slice instead of the corresponding cluster name key.
- pkg/util/util.go (CalculateClusterIncludesExcludes): Implemented regex matching (`regexp.MatchString`) for cluster filtering, aligning the backend functionality with the CLI instruction documentation ("comma separated list of cluster names and/or regular expressions").
- pkg/util/util.go (FilterItems): Refactored the core include/exclude iteration loop to ensure that correctly matched clusters are actually recorded and appended into the final returned slice.

Here is why I think this is needed:
- Main:
```
$ ./kr8-main generate -C '^kube-1$,^kube-2$'
5:15PM INF Processing component cluster=compose component=sealed_secrets
5:15PM INF Processing component cluster=compose component=external_dns
5:15PM INF Processing component cluster=kube-2 component=sealed_secrets_old
5:15PM INF Processing component cluster=kube-2 component=external_dns
5:15PM INF Processing component cluster=kube-2 component=sealed_secrets
5:15PM INF Loaded cluster cache cluster=kube-2-cache file=generated/kube-2-cache/.kr8_cache
5:15PM INF Processing component cluster=kube-2-cache component=sealed_secrets_old
5:15PM INF Processing component cluster=kube-2-cache component=external_dns
5:15PM INF Processing component cluster=kube-2-cache component=sealed_secrets
5:15PM INF Loaded cluster cache cluster=kube-2-cache-compress file=generated/kube-2-cache-compress/.kr8_cache
5:15PM INF Processing component cluster=kube-1 component=sealed_secrets
5:15PM INF Processing component cluster=kube-1 component=echo_test
5:15PM INF Processing component cluster=kube-1 component=external_dns
5:15PM INF Processing component cluster=kube-1 component=echo_test_compose
5:15PM INF + Component matches cache, skipping cluster=kube-2-cache component=sealed_secrets
5:15PM INF Processing component cluster=kube-2-cache-compress component=external_dns
5:15PM INF + Component matches cache, skipping cluster=kube-2-cache component=sealed_secrets_old
5:15PM INF Processing component cluster=kube-2-cache-compress component=sealed_secrets
5:15PM INF + Component matches cache, skipping cluster=kube-2-cache component=external_dns
5:15PM INF Processing component cluster=kube-2-cache-compress component=sealed_secrets_old
5:15PM INF + Component matches cache, skipping cluster=kube-2-cache-compress component=sealed_secrets
5:15PM INF + Component matches cache, skipping cluster=kube-2-cache-compress component=sealed_secrets_old
5:15PM INF Processing component cluster=docs-kube-1 component=echo_test
5:15PM INF Processing component cluster=docs-kube-1 component=echo_test_compose
5:15PM INF + Component matches cache, skipping cluster=kube-2-cache-compress component=external_dns
5:15PM INF Processing component cluster=docs-kube-1 component=jsonnetStorageClasses
5:15PM INF Processing component cluster=docs-kube-1 component=nativeFuncs
5:15PM INF Processing component cluster=docs-kube-1 component=template_examples

```
- My branch:
```
$ ./kr8 generate -C '^kube-1$,^kube-2$'
5:10PM INF Processing component cluster=kube-1 component=sealed_secrets
5:10PM INF Processing component cluster=kube-1 component=echo_test
5:10PM INF Processing component cluster=kube-1 component=echo_test_compose
5:10PM INF Processing component cluster=kube-1 component=external_dns
5:10PM INF Processing component cluster=kube-2 component=sealed_secrets_old
5:10PM INF Processing component cluster=kube-2 component=external_dns
5:10PM INF Processing component cluster=kube-2 component=sealed_secrets
```

Happy to hear what you think about this issue.